### PR TITLE
Fix empty candlesticks on ios

### DIFF
--- a/example/utils/generateData.js
+++ b/example/utils/generateData.js
@@ -30,6 +30,14 @@ export const generateMockData = () => {
       close: parseFloat(close.toFixed(2)),
       vol: parseFloat(volume.toFixed(2))  // Native code expects 'vol' not 'volume'
     })
+
+    // TO TEST EMPTY CANDLESTICKS UNCOMMENT THIS
+    // if (i % 5 === 0) {
+    //   data[data.length - 1].vol = 0 // Simulate occasional volume spikes
+    //   data[data.length - 1].close = data[data.length - 1].open // Simulate occasional price stability
+    //   data[data.length - 1].high = data[data.length - 1].open // Simulate occasional price stability
+    //   data[data.length - 1].low = data[data.length - 1].open // Simulate occasional price stability
+    // }
     
     lastClose = close
   }

--- a/ios/Classes/HTMainDraw.swift
+++ b/ios/Classes/HTMainDraw.swift
@@ -49,8 +49,43 @@ class HTMainDraw: NSObject, HTKLineDrawProtocol {
         } else {
             // Draw wick first (behind body)
             drawCandle(high: model.high, low: model.low, maxValue: maxValue, minValue: minValue, baseY: baseY, height: height, index: index, width: configManager.candleLineWidth, color: wickColor, verticalAlignBottom: false, context: context, configManager: configManager)
+
             // Draw body second (on top)
-            drawCandle(high: findValue(true), low: findValue(false), maxValue: maxValue, minValue: minValue, baseY: baseY, height: height, index: index, width: configManager.candleWidth, color: color, verticalAlignBottom: false, context: context, configManager: configManager)
+            let candleHigh = findValue(true)
+            let candleLow = findValue(false)
+
+            // Handle case when open == close (doji candlestick)
+            if candleHigh == candleLow {
+                // Draw a thin horizontal line to make the doji visible, similar to Android behavior
+                drawCandleWithMinHeight(high: candleHigh, low: candleLow, maxValue: maxValue, minValue: minValue, baseY: baseY, height: height, index: index, width: configManager.candleWidth, color: color, context: context, configManager: configManager)
+            } else {
+                drawCandle(high: candleHigh, low: candleLow, maxValue: maxValue, minValue: minValue, baseY: baseY, height: height, index: index, width: configManager.candleWidth, color: color, verticalAlignBottom: false, context: context, configManager: configManager)
+            }
+        }
+    }
+
+    func drawCandleWithMinHeight(high: CGFloat, low: CGFloat, maxValue: CGFloat, minValue: CGFloat, baseY: CGFloat, height: CGFloat, index: Int, width: CGFloat, color: UIColor, context: CGContext, configManager: HTKLineConfigManager) {
+        let itemWidth = configManager.itemWidth
+        let scale = (maxValue - minValue) / height
+        let paddingHorizontal = (itemWidth - width) / 2.0
+        let x = CGFloat(index) * itemWidth + paddingHorizontal
+        let y = baseY + (maxValue - high) / scale
+
+        // Ensure minimum height of 1 pixel for doji candles (open == close)
+        let minHeightInPixels: CGFloat = 1.0
+        let candleHeight = max(minHeightInPixels, (high - low) / scale)
+
+        context.setFillColor(color.cgColor)
+
+        if configManager.candleCornerRadius > 0 {
+            // Draw rounded rectangle
+            let rect = CGRect(x: x, y: y, width: width, height: candleHeight)
+            let path = UIBezierPath(roundedRect: rect, cornerRadius: configManager.candleCornerRadius)
+            context.addPath(path.cgPath)
+            context.fillPath()
+        } else {
+            // Draw regular rectangle with minimum height
+            context.fill(CGRect.init(x: x, y: y, width: width, height: candleHeight))
         }
     }
 


### PR DESCRIPTION
# Pull Request

## Summary
Empty candlesticks had no representation whatsoever on iOS. Now they show a thin line.

**Linear ticket:** PRO-2734

## Author Checklist
- [x] PR tested locally
- [x] PR tested on preview

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/elliottech/react-native-kline-view/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
